### PR TITLE
Fix a bug in helm-notmuch-maybe-match-incomplete

### DIFF
--- a/helm-notmuch.el
+++ b/helm-notmuch.el
@@ -98,7 +98,7 @@ slows down searches."
 
 (defun helm-notmuch-maybe-match-incomplete (pattern)
   (if helm-notmuch-match-incomplete-words
-      (if (string-match-p "[:alnum:]$" pattern)
+      (if (string-match-p "[[:alnum:]]$" pattern)
           (concat pattern "*")
         pattern)
     pattern))


### PR DESCRIPTION
The regexp syntax used is wrong, eg `(string-match-p "[:alnum:]$" "hardfor")` would evaluate to nil.
What it actually currently checks is if the string ends in one of the `alnum` letters.