### PR TITLE
use notmuch-command instead of hardcoded "notmuch"

### DIFF
--- a/helm-notmuch.el
+++ b/helm-notmuch.el
@@ -56,7 +56,7 @@ slows down searches."
   :type 'boolean)
 
 (defun helm-notmuch-collect-candidates ()
-  (let* ((cmds (delq nil (list "notmuch" "search"
+  (let* ((cmds (delq nil (list notmuch-command "search"
                                (and (> helm-notmuch-max-matches 0)
                                     (concat "--limit=" (number-to-string helm-notmuch-max-matches)))
                                helm-pattern)))


### PR DESCRIPTION
handy for switching between different notmuch configs or if you execute notmuch commands remotely over ssh.