### PR TITLE
A couple of improvements to notmuch actions

### DIFF
--- a/helm-notmuch.el
+++ b/helm-notmuch.el
@@ -154,6 +154,11 @@ slows down searches."
         pattern)
     pattern))
 
+(defun helm-notmuch-show (candidate)
+  "Display CANDIDATE using notmuch-show, retaining the query context."
+  (notmuch-show candidate nil nil
+                (helm-notmuch-maybe-match-incomplete helm-pattern)))
+
 (defvar helm-source-notmuch
   (helm-build-async-source "Search email with notmuch"
     :candidates-process #'helm-notmuch-collect-candidates
@@ -161,7 +166,7 @@ slows down searches."
     :requires-pattern 2
     :pattern-transformer #'helm-notmuch-maybe-match-incomplete
     :nohighlight t
-    :action '(("Show message in notmuch" . notmuch-show))))
+    :action '(("Show message in notmuch" . helm-notmuch-show))))
 
 ;;;###autoload
 (defun helm-notmuch ()

--- a/helm-notmuch.el
+++ b/helm-notmuch.el
@@ -159,6 +159,12 @@ slows down searches."
   (notmuch-show candidate nil nil
                 (helm-notmuch-maybe-match-incomplete helm-pattern)))
 
+(defun helm-notmuch-search (candidate)
+  "Display notmuch query in notmuch-search buffer, highlighting CANDIDATE."
+  (notmuch-search (helm-notmuch-maybe-match-incomplete helm-pattern)
+                  nil
+                  (replace-regexp-in-string "^thread:" "" candidate)))
+
 (defvar helm-source-notmuch
   (helm-build-async-source "Search email with notmuch"
     :candidates-process #'helm-notmuch-collect-candidates
@@ -166,7 +172,8 @@ slows down searches."
     :requires-pattern 2
     :pattern-transformer #'helm-notmuch-maybe-match-incomplete
     :nohighlight t
-    :action '(("Show message in notmuch" . helm-notmuch-show))))
+    :action '(("Show message in notmuch" . helm-notmuch-show)
+              ("Open notmuch-search query buffer" . helm-notmuch-search))))
 
 ;;;###autoload
 (defun helm-notmuch ()


### PR DESCRIPTION
This adds support for carrying over the query to notmuch-show so the displayed
thread will be filtered by the search term, and adds a second action to open the
current query in a notmuch-search buffer (for subsequent filtering, for instance).